### PR TITLE
onclick

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -135,7 +135,7 @@ export default function Navbar() {
             >
               {/* Top row: close */}
               <div className="mb-8 flex items-center justify-between">
-                <CartIcon variant="outline" />
+                <CartIcon variant="outline" onClick={closeMobileSidebar} />
 
                 {/* <div className="flex justify-end"> */}
                 <button onClick={closeMobileSidebar} className="cursor-pointer">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - On mobile, tapping the cart icon in the sidebar header now closes the sidebar, offering an additional way to exit. Desktop behavior remains unchanged, and the existing close button continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->